### PR TITLE
Verify serialport availability before opening

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ import {
 import {
     openJLink,
     closeJLink,
+    verifySerialPortAvailable,
     getDeviceFamily,
     validateFirmware,
     programFirmware,
@@ -355,7 +356,8 @@ function setupDevice(selectedDevice, options) {
 
         if (jprog && selectedDevice.traits.includes('jlink')) {
             let firmwareFamily;
-            return openJLink(selectedDevice)
+            return verifySerialPortAvailable(selectedDevice)
+                .then(() => openJLink(selectedDevice))
                 .then(() => getDeviceFamily(selectedDevice))
                 .then(family => {
                     firmwareFamily = jprog[family];


### PR DESCRIPTION
On Windows, nrfjprog will hang when opening J-Link devices that are in a bad state. A device may get into this state if left connected to the PC overnight.

nRF Connect performed this check as part of the old serial port selector implementation, but it fits better here now that we have the nrfjprog interaction in this library.